### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Fork and rename, or simply copy this repository.
 - [ ] `npm install` to install dependencies.
 - [ ] Execute `npm run dev` to run a development server that autoreloads when you make changes to the article ("hot-reloading"). The console output will link you to a hot-reloading preview of the article.
 - [ ] Your article text is in `src/index.ejs`.
-- [ ] Your article metadata is in a tag called `distill-frontmatter` in the same (`src/index.ejs`) file. It contains a password field, which you should customize or remove while you're working oon the article.
+- [ ] Your article metadata is in a tag called `distill-frontmatter` in the same (`src/index.ejs`) file. It contains a password field, which you should customize or remove while you're working on the article.
 
 Components and diagrams are stored in `src`. The `.html` files are [svelte](https://svelte.technology/guide) components, the `.js` files are compilation endpoints that are also defined in `webpack.config.js`. These compiled endpoints are then consumed by hand authored `.ejs` files in `src`, such as `index.ejs` which contains your content. For most articles you can simply use the provided `index.ejs` for your text, `index.js` to instantiate diagrams, and `.html` svelte files to create them.
 


### PR DESCRIPTION
Corrected a small typo in README.

Cheers for the excellent framework :smile: 